### PR TITLE
Sets and enforces a threshold for the number of swaps that can be executed within a 24-hour period.

### DIFF
--- a/src/interfaces/modules/IRebaseStrategy.sol
+++ b/src/interfaces/modules/IRebaseStrategy.sol
@@ -18,19 +18,29 @@ interface IRebaseStrategy {
     error RebaseStrategyDataCannotBeZero();
     error OnlyRebaseInactivityCannotBeSelected();
     error RebaseInactivityCannotBeZero();
+    error SwapsThresholdExceeded();
 
+    /// @param strategyId The strategy's key is a hash of a preimage composed by the owner & token ID
+    /// @param mode ModuleId: one of four basic modes 1: left, 2: Right, 3: Both, 4: Static
+    /// @param actionNames to hold multiple valid modes
     struct ExecutableStrategiesData {
         bytes32 strategyID;
         uint256 mode;
-        bytes32[2] actionNames; // Array to hold multiple valid modes
-    }
-
-    struct StrategyInputData {
-        bytes32 strategyID;
-        bytes rebaseOptions;
+        bytes32[2] actionNames;
     }
 
     function checkInputData(ICLTBase.StrategyPayload memory data) external returns (bool);
+
+    /// @param pool The Uniswap V3 pool
+    /// @param strategyId The strategy's key is a hash of a preimage composed by the owner & token ID
+    /// @param tickLower The lower tick of the A51's LP position
+    /// @param tickUpper The upper tick of the A51's LP position
+    /// @param tickLower The lower tick of the A51's LP position
+    /// @param shouldMint Bool weather liquidity should be added on AMM or hold in contract
+    /// @param zeroForOne The direction of the swap, true for token0 to token1, false for token1 to token0
+    /// @param swapAmount The amount of the swap, which implicitly configures the swap as exact input (positive), or
+    /// exact output (negative)
+    /// @param sqrtPriceLimitX96 The Q64.96 sqrt price limit. If zero for one, the price cannot be less than this
 
     struct ExectuteStrategyParams {
         IUniswapV3Pool pool;

--- a/src/modules/rebasing/RebaseModule.sol
+++ b/src/modules/rebasing/RebaseModule.sol
@@ -107,7 +107,7 @@ contract RebaseModule is ModeTicksCalculation, AccessControl, IRebaseStrategy {
                 (,, uint256 _lastUpdateTimeStamp, uint256 _manualSwapsCount) =
                     abi.decode(actionStatus, (uint256, bool, uint256, uint256));
 
-                (lastUpdateTimeStamp, manualSwapsCount) = checkSwapsInADay(_lastUpdateTimeStamp, _manualSwapsCount);
+                (lastUpdateTimeStamp, manualSwapsCount) = _checkSwapsInADay(_lastUpdateTimeStamp, _manualSwapsCount);
             } else {
                 lastUpdateTimeStamp = block.timestamp;
                 manualSwapsCount = 1;

--- a/src/modules/rebasing/RebaseModule.sol
+++ b/src/modules/rebasing/RebaseModule.sol
@@ -141,8 +141,8 @@ contract RebaseModule is ModeTicksCalculation, AccessControl, IRebaseStrategy {
     /// @dev This function is used to limit the number of manual swaps within a 24-hour period.
     /// @param lastUpdateTimeStamp The last time the swap count was updated.
     /// @param manualSwapsCount The current count of manual swaps.
-    /// @return updatedTime The updated time stamp.
-    /// @return swapCount The updated swap count.
+    /// @return uint256 The updated time stamp.
+    /// @return uint256 The updated swap count.
     /// @custom:errors SwapsThresholdExceeded if the number of swaps exceeds the set threshold within a day.
     function checkSwapsInADay(
         uint256 lastUpdateTimeStamp,
@@ -150,14 +150,12 @@ contract RebaseModule is ModeTicksCalculation, AccessControl, IRebaseStrategy {
     )
         internal
         view
-        returns (uint256 updatedTime, uint256 swapCount)
+        returns (uint256, uint256)
     {
         if (block.timestamp <= lastUpdateTimeStamp + ONE_DAY) {
             if (manualSwapsCount >= swapsThreshold) revert SwapsThresholdExceeded();
             return (lastUpdateTimeStamp, manualSwapsCount += 1);
-        }
-
-        if (block.timestamp > lastUpdateTimeStamp + ONE_DAY) {
+        } else {
             return (block.timestamp, manualSwapsCount = 1);
         }
     }
@@ -435,7 +433,6 @@ contract RebaseModule is ModeTicksCalculation, AccessControl, IRebaseStrategy {
     /// @notice Updates the swaps threshold.
     /// @dev Reverts if the new threshold is less than zero.
     /// @param _newThreshold The new liquidity threshold value.
-
     function updateSwapsThreshold(uint256 _newThreshold) external onlyOperator {
         if (_newThreshold < 0) {
             revert InvalidThreshold();

--- a/src/modules/rebasing/RebaseModule.sol
+++ b/src/modules/rebasing/RebaseModule.sol
@@ -19,8 +19,6 @@ contract RebaseModule is ModeTicksCalculation, AccessControl, IRebaseStrategy {
     /// @notice Threshold for liquidity consideration
     uint256 public liquidityThreshold = 1e3;
 
-    uint256 private constant ONE_DAY = 1 days;
-
     /// @notice Threshold for swaps in manual override
     uint256 public swapsThreshold = 5;
 
@@ -144,7 +142,7 @@ contract RebaseModule is ModeTicksCalculation, AccessControl, IRebaseStrategy {
     /// @return uint256 The updated time stamp.
     /// @return uint256 The updated swap count.
     /// @custom:errors SwapsThresholdExceeded if the number of swaps exceeds the set threshold within a day.
-    function checkSwapsInADay(
+    function _checkSwapsInADay(
         uint256 lastUpdateTimeStamp,
         uint256 manualSwapsCount
     )
@@ -152,7 +150,7 @@ contract RebaseModule is ModeTicksCalculation, AccessControl, IRebaseStrategy {
         view
         returns (uint256, uint256)
     {
-        if (block.timestamp <= lastUpdateTimeStamp + ONE_DAY) {
+        if (block.timestamp <= lastUpdateTimeStamp + 1 days) {
             if (manualSwapsCount >= swapsThreshold) revert SwapsThresholdExceeded();
             return (lastUpdateTimeStamp, manualSwapsCount += 1);
         } else {

--- a/test/ExecuteStrategies.t.sol
+++ b/test/ExecuteStrategies.t.sol
@@ -177,7 +177,7 @@ contract ExecuteStrategiesTest is Test, RebaseFixtures {
 
         bytes32 strategyId = createStrategyAndDeposit(rebaseActions, 1500, owner, 1, 1, true);
 
-        bytes32[] memory strategyIDs = new bytes32[]( 1);
+        bytes32[] memory strategyIDs = new bytes32[](1);
 
         strategyIDs[0] = strategyId;
 
@@ -251,7 +251,7 @@ contract ExecuteStrategiesTest is Test, RebaseFixtures {
     }
 
     function testExecutingStrategyWithEmptyID() public {
-        bytes32[] memory strategyIDs = new bytes32[]( 10);
+        bytes32[] memory strategyIDs = new bytes32[](10);
         vm.expectRevert();
         rebaseModule.executeStrategies(strategyIDs);
     }
@@ -263,7 +263,7 @@ contract ExecuteStrategiesTest is Test, RebaseFixtures {
 
         createStrategyAndDeposit(rebaseActions, 1500, owner, 1, 1, true);
 
-        bytes32[] memory strategyIDs = new bytes32[]( 1);
+        bytes32[] memory strategyIDs = new bytes32[](1);
 
         bytes32 strategyID = keccak256(abi.encode(users[2], 1));
 
@@ -280,7 +280,7 @@ contract ExecuteStrategiesTest is Test, RebaseFixtures {
 
         createStrategyAndDeposit(rebaseActions, 1500, owner, 1, 1, true);
 
-        bytes32[] memory strategyIDs = new bytes32[]( 1);
+        bytes32[] memory strategyIDs = new bytes32[](1);
 
         bytes32 strategyID = bytes32(0);
 
@@ -331,54 +331,6 @@ contract ExecuteStrategiesTest is Test, RebaseFixtures {
         rebaseModule.checkStrategiesArray(data);
     }
 
-    function testExecuteStrategiesWithLowLiquidity() public {
-        ICLTBase.StrategyPayload[] memory rebaseActions = new ICLTBase.StrategyPayload[](1);
-        rebaseActions[0].actionName = rebaseModule.PRICE_PREFERENCE();
-        rebaseActions[0].data = abi.encode(23, 43);
-
-        ICLTBase.PositionActions memory positionActions;
-
-        positionActions.mode = 1;
-        positionActions.exitStrategy = new ICLTBase.StrategyPayload[](0);
-        positionActions.rebaseStrategy = rebaseActions;
-        positionActions.liquidityDistribution = new ICLTBase.StrategyPayload[](0);
-
-        initStrategy(800);
-        base.createStrategy(strategyKey, positionActions, 0, 0, true, false);
-
-        ICLTBase.DepositParams memory depositParams;
-
-        bytes32 strategyID = getStrategyID(owner, 1);
-
-        depositParams.strategyId = strategyID;
-        depositParams.amount0Desired = 1000;
-        depositParams.amount1Desired = 1000;
-        depositParams.amount0Min = 0;
-        depositParams.amount1Min = 0;
-        depositParams.recipient = owner;
-
-        base.deposit(depositParams);
-
-        executeSwap(token0, token1, pool.fee(), owner, 500e18, 0, 0);
-
-        bytes memory encodedError = abi.encodeWithSignature("InvalidThreshold()");
-        vm.expectRevert(encodedError);
-        rebaseModule.updateLiquidityThreshold(0);
-
-        rebaseModule.updateLiquidityThreshold(1000);
-
-        bytes32[] memory strategyIDs = new bytes32[]( 1);
-
-        strategyIDs[0] = strategyID;
-
-        rebaseModule.executeStrategies(strategyIDs);
-        (ICLTBase.StrategyKey memory key,,,,,,,, ICLTBase.Account memory account) = base.strategies(strategyID);
-
-        (uint256 reserve0, uint256 reserve1) = getStrategyReserves(key, account.uniswapLiquidity);
-        assertEq(reserve0 > 0, true);
-        assertEq(reserve1 == 0, true);
-    }
-
     // edge
     // 5
     function test_fuzz_ExecuteStrategyAllModesWithOnlyRebaseInactivity(uint256 mode) public {
@@ -390,7 +342,7 @@ contract ExecuteStrategiesTest is Test, RebaseFixtures {
 
         bytes32 strategyID = createStrategyAndDeposit(rebaseActions, 1500, owner, 1, mode, true);
 
-        bytes32[] memory strategyIDs = new bytes32[]( 1);
+        bytes32[] memory strategyIDs = new bytes32[](1);
 
         strategyIDs[0] = strategyID;
 
@@ -820,7 +772,6 @@ contract ExecuteStrategiesTest is Test, RebaseFixtures {
      * Random scenario 1
      * Rebase inactivity 2 and another user comes after 1 rebase
      */
-
     function testScenario1() public {
         ICLTBase.StrategyPayload[] memory rebaseActions = new ICLTBase.StrategyPayload[](2);
 
@@ -989,8 +940,6 @@ contract ExecuteStrategiesTest is Test, RebaseFixtures {
         depositParams.recipient = owner;
 
         base.deposit(depositParams);
-
-        rebaseModule.updateLiquidityThreshold(1000);
 
         executeSwap(token1, token0, pool.fee(), owner, 1500e18, 0, 0);
         _hevm.warp(block.timestamp + 3600);


### PR DESCRIPTION
### Key Changes:

1. Swap Threshold Enforcement: Added logic in the **checkSwapsInADay** function to check the current number of swaps against a predefined threshold. If the number of swaps exceeds this limit within a single day, the function reverts to prevent any further swaps.

2. Timestamp Management: The feature includes efficient tracking and updating of timestamps associated with each swap. This ensures that the threshold is enforced accurately over a rolling 24-hour window.

3. Updated Strategy Execution Logic: Modified the **executeStrategy** function to incorporate the swap threshold check. This function now calls checkSwapsInADay to ensure compliance with the swap limit before proceeding with strategy execution.

4. Error Handling: Introduced a new error, **SwapsThresholdExceeded**, which is triggered when an attempt to execute a swap exceeds the daily limit.
 
5. Test Cases: Added comprehensive unit tests to validate the functionality of the swap threshold, including edge cases and error handling.